### PR TITLE
fix startup for static IP in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,8 @@ PoolControllerPlatform.prototype.SSDPDiscovery = function () {
             self.log('Can not find nodejs-PoolController after %s seconds.', elapsedTime)
         }, 5000)
 
-
+    } else {
+      self.validateVersion(self.config.ip_address + "/device");
     }
 }
 


### PR DESCRIPTION
In the non-SSDP case, validateVersion was not being called and thus no socketInit